### PR TITLE
fixes #324

### DIFF
--- a/GPSTest/src/main/java/com/android/gpstest/util/UIUtils.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/UIUtils.java
@@ -279,16 +279,16 @@ public class UIUtils {
 
         body.append("\n\n\n");
 
-        Intent send = new Intent(Intent.ACTION_SEND);
-        send.putExtra(Intent.EXTRA_EMAIL, new String[]{email});
+        Intent sendemail = new Intent(Intent.ACTION_SEND);
+        sendemail.putExtra(Intent.EXTRA_EMAIL, new String[]{email});
 
         String subject = context.getString(R.string.feedback_subject);
 
-        send.putExtra(Intent.EXTRA_SUBJECT, subject);
-        send.putExtra(Intent.EXTRA_TEXT, body.toString());
-        send.setType("message/rfc822");
+        sendemail.putExtra(Intent.EXTRA_SUBJECT, subject);
+        sendemail.putExtra(Intent.EXTRA_TEXT, body.toString());
+        sendemail.setType("message/rfc822");
         try {
-            context.startActivity(Intent.createChooser(send, subject));
+            context.startActivity(sendemail));
         } catch (ActivityNotFoundException e) {
             Toast.makeText(context, R.string.feedback_error, Toast.LENGTH_LONG)
                     .show();


### PR DESCRIPTION
Don't let the user pick because we intent him to use email and it wont work if he selects a non-email messenger app. Take the default email app.

Yes, this sucks for people with multiple email clients, but if we don;t do this much of the feedback goes lost because users can't figure out how to send it. Android doesn't have a way that I know of of letting the user choose between only email capable apps.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Acknowledge that you're contributing your code under Apache v2.0 license

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.